### PR TITLE
check_compliance.py: fallback on result.message when no ._elem.text

### DIFF
--- a/scripts/check_compliance.py
+++ b/scripts/check_compliance.py
@@ -737,7 +737,8 @@ def main():
         for case in failed_cases:
             # not clear why junitxml doesn't clearly expose the most
             # important part of its underlying etree.Element
-            errmsg = case.result._elem.text.strip()
+            errmsg = case.result._elem.text
+            errmsg = errmsg.strip() if errmsg else case.result.message
             logging.error("Test %s failed: %s", case.name, errmsg)
 
     sys.exit(errors)


### PR DESCRIPTION
There's not always an _elem.text. To test:

 ZEPHYR_BASE=/whatever ./scripts/check_compliance.py -m Kconfig

- Before:

  AttributeError: 'NoneType' object has no attribute 'strip'

- After:

  Running Kconfig tests...
  1 Errors found
  ERROR   : Test Kconfig failed: Can't find Kconfig
