### PR TITLE
checks: codeowners: Fail on missing trailing / and missing paths

### DIFF
--- a/scripts/check_compliance.py
+++ b/scripts/check_compliance.py
@@ -280,11 +280,13 @@ class Codeowners(ComplianceTest):
                         if abs_path.endswith("/"):
                             abs_path = abs_path + "**"
                         elif os.path.isdir(abs_path):
-                            error("Wrong syntax: {}".format(abs_path))
+                            self.add_failure("Expected / after directory '{}' "
+                                             "in CODEOWNERS".format(path))
                             continue
                         g = glob.glob(abs_path, recursive=True)
                         if not g:
-                            error("Path does not exist: {}".format(path))
+                            self.add_failure("Path '{}' not found, in "
+                                             "CODEOWNERS".format(path))
                         else:
                             files = []
                             if not add_base:


### PR DESCRIPTION
Fail the CODEOWNERS check if there are missing trailing slashes or
missing paths, instead of just printing a warning to stderr. Otherwise,
bad entries will probably keep getting added to CODEOWNERS.

Clarify the error message when / is missing too.