### PR TITLE
check_compliance.py: warn about skipped tests and no .result

### DIFF
--- a/scripts/check_compliance.py
+++ b/scripts/check_compliance.py
@@ -728,8 +728,15 @@ def main():
         errors = report_to_github(args.repo, args.pull_request, args.sha, suite, docs)
     else:
         for case in suite:
-            if case.result and case.result.type != 'skipped':
-                failed_cases.append(case)
+            if case.result:
+                if case.result.type == 'skipped':
+                    logging.warning("Skipped %s, %s", case.name, case.result.message)
+                else:
+                    failed_cases.append(case)
+            else:
+                # Some checks like codeowners can produce no .result
+                logging.info("No JUnit result for %s", case.name)
+
         errors = len(failed_cases)
 
     if errors:
@@ -740,6 +747,7 @@ def main():
             errmsg = case.result._elem.text.strip()
             logging.error("Test %s failed: %s", case.name, errmsg)
 
+    print("\nComplete results in %s" % args.output)
     sys.exit(errors)
 
 if __name__ == "__main__":


### PR DESCRIPTION
The only indication that a test has been skipped (for instance because
checkpatch or scancode couldn't be found) requires opening the
compliance.xml file.

Log a warning() for every skipped test including the reason why it was
skipped.  Also remind users that the complete, reference results for CI
are in the XML file so they realize the standard output is informative
and sometimes approximative.

Sample output:
WARNING : Skipped checkpatch, checkpatch script not found
WARNING : Skipped Kconfig, Not a Zephyr tree
WARNING : Skipped License, scancode-toolkit not installed

Signed-off-by: Marc Herbert <marc.herbert@intel.com>