### PR TITLE
scripts: check_compliance: Check for kconfig variables declared

### DIFF
--- a/scripts/check_compliance.py
+++ b/scripts/check_compliance.py
@@ -156,6 +156,9 @@ class KconfigCheck(ComplianceTest):
         os.environ["BOARD_DIR"] = "boards/*/*"
         os.environ["ARCH"] = "*"
         os.environ["PROJECT_BINARY_DIR"] = tempfile.gettempdir()
+        os.environ["PYTHON_EXECUTABLE"] = os.path.normpath(sys.executable)
+        os.environ["KCONFIG_CONFIG"] = "dummy"
+        os.environ["KERNELVERSION"] = "dummy"
         os.environ['GENERATED_DTS_BOARD_CONF'] = "dummy"
 
         # For multi repo support
@@ -164,6 +167,16 @@ class KconfigCheck(ComplianceTest):
         # Enable strict Kconfig mode in Kconfiglib, which assumes there's just a
         # single Kconfig tree and warns for all references to undefined symbols
         os.environ["KCONFIG_STRICT"] = "y"
+
+        kconfig_env_var_list_path = os.path.join(self.zephyr_base, "cmake/kconfig_env_vars.txt")
+        kconfig_env_vars = set(open(kconfig_env_var_list_path).read().splitlines())
+
+        missing_vars = kconfig_env_vars.difference(os.environ) 
+        if missing_vars:
+            self.case.result = Failure("error environmental variables {1} listed in {0} "
+                                       "are not declared in check_compliance.py".format(
+                                       kconfig_env_var_list_path, missing_vars), "failure")
+            return
 
         try:
             kconf = kconfiglib.Kconfig()


### PR DESCRIPTION
Add support for a single file as source of truth for environmental
variables declared for Kconfig in Cmake. It's coupled with a change in
the cmake build system where you declare the environmental variables for
Kconfig in a single text file. This will give you an error if the script
does not set the required variables and will list which variables are
missing.

This is coupled with: https://github.com/zephyrproject-rtos/zephyr/pull/14072

Signed-off-by: Sigvart Hovland <sigvart.m@gmail.com>