### PR TITLE
bugfix: missing requirement in requirements.txt for check_compliance.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ sh==1.11
 six==1.11.0
 urllib3==1.24.1
 wrapt==1.10.11
+colorama==0.4.1


### PR DESCRIPTION
` check_compliance.py` uses colorama which was not in requirements.txt