### PR TITLE
check_compliance.py: fix Error(msg, "skipped")

### DIFF
--- a/scripts/check_compliance.py
+++ b/scripts/check_compliance.py
@@ -105,7 +105,7 @@ class ComplianceTest:
         if self.case.result:
             msg += "\n\nFailures before error: " + self.case.result._elem.text
 
-        self.case.result = Error(msg, "skipped")
+        self.case.result = Error(msg, "error")
 
         raise EndTest
 


### PR DESCRIPTION
Replace with Error(msg, "error")

Typo introduced in previous commit / PR #26. Fixes the following
console output:

  WARNING : Skipped Gitlint failed: ...

I don't know the impact on Github however this just restores the
previous behavior.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>