### PR TITLE
scripts: check_compliance: fix for multi-image

### DIFF
--- a/scripts/check_compliance.py
+++ b/scripts/check_compliance.py
@@ -205,6 +205,7 @@ class KconfigCheck(ComplianceTest):
         os.environ["ARCH_DIR"] = "arch/"
         os.environ["BOARD_DIR"] = "boards/*/*"
         os.environ["ARCH"] = "*"
+        os.environ["CMAKE_BINARY_DIR"] = tempfile.gettempdir()
         os.environ["PROJECT_BINARY_DIR"] = tempfile.gettempdir()
         os.environ['GENERATED_DTS_BOARD_CONF'] = "dummy"
 


### PR DESCRIPTION
Check_compliance fails for multi-image this should fix this. Should not be merged before https://github.com/zephyrproject-rtos/zephyr/pull/13672 is in.

Signed-off-by: Sigvart Hovland <sigvart.m@gmail.com>