### PR TITLE
check_compliance.py: Run pylint on Python scripts

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
 /scripts/check_compliance.py				@nashif
 /scripts/what_changed.py                                @nashif
+/scripts/pylintrc                                       @ulfalizer @mbolivar
 /CODEOWNERS						@nashif

--- a/scripts/check_compliance.py
+++ b/scripts/check_compliance.py
@@ -41,6 +41,10 @@ def git(*args):
     # Hack: Setting _cwd to the working dir seems pointless as of writing (it
     # should be the default), but keep it around in case it's working around
     # some issue
+
+    # pylint doesn't like how the sh library works.
+    #
+    # pylint: disable=unexpected-keyword-arg
     return sh.git(*args, _tty_out=False, _cwd=os.getcwd())
 
 
@@ -102,7 +106,6 @@ class ComplianceTest:
         Run testcase
         :return:
         """
-        pass
 
     def error(self, msg):
         """

--- a/scripts/pylintrc
+++ b/scripts/pylintrc
@@ -1,0 +1,246 @@
+# Copyright (c) 2019, Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# pylint configuration for the PyLint check in check_compliance.py.
+#
+# To run pylint manually with this configuration from the Zephyr repo, do
+#
+#     pylint3 --rcfile=ci-tools/scripts/pylintrc <Python file>
+#
+# This command will check all scripts:
+#
+#     pylint3 --rcfile=ci-tools/scripts/pylintrc $(git ls-files '*.py')
+
+[MASTER]
+
+# Use multiple processes
+jobs=0
+
+# Do not pickle collected data for comparisons
+persistent=no
+
+
+[REPORTS]
+
+# Only show messages, not full report
+reports=no
+
+# Disable score
+score=no
+
+
+[MESSAGES CONTROL]
+
+# Only enable specific (hopefully) uncontroversial warnings. Use
+# 'pylint3 --list-msgs' to list messages and their IDs.
+#
+# These might be nice to check too, but currently trigger false positives:
+#
+#   no-member
+#   arguments-differ
+#   redefine-in-handler
+#   abstract-method
+#
+# These might be too controversial:
+#
+#   no-else-return
+#   consider-using-get
+#   redefined-builtin
+#
+# These tell you to use logger.warning("foo %d bar", 3) instead of e.g.
+# logger.warning("foo {} bar".format(3)), but it's not a clear win in all
+# cases. f-strings would be nicer too, and it's easier to convert from format()
+# to those.
+#
+#   logging-not-lazy
+#   logging-format-interpolation
+#   logging-fstring-interpolation
+
+disable=all
+# Identifiers are in the same order as in 'pylint3 --list-msgs'
+enable=
+    empty-docstring,
+    unneeded-not,
+    singleton-comparison,
+    misplaced-comparison-constant,
+    unidiomatic-typecheck,
+    consider-using-enumerate,
+    consider-iterating-dictionary,
+    bad-classmethod-argument,
+    bad-mcs-method-argument,
+    bad-mcs-classmethod-argument,
+    single-string-used-for-slots,
+    trailing-newlines,
+    trailing-whitespace,
+    missing-final-newline,
+    superfluous-parens,
+    mixed-line-endings,
+    unexpected-line-ending-format,
+    invalid-characters-in-docstring,
+    useless-import-alias,
+    len-as-condition,
+    syntax-error,
+    init-is-generator,
+    return-in-init,
+    function-redefined,
+    not-in-loop,
+    return-outside-function,
+    yield-outside-function,
+    nonexistent-operator,
+    duplicate-argument-name,
+    abstract-class-instantiated,
+    bad-reversed-sequence,
+    too-many-star-expressions,
+    invalid-star-assignment-target,
+    star-needs-assignment-target,
+    nonlocal-and-global,
+    continue-in-finally,
+    nonlocal-without-binding,
+    misplaced-format-function,
+    method-hidden,
+    access-member-before-definition,
+    no-method-argument,
+    no-self-argument,
+    invalid-slots-object,
+    assigning-non-slot,
+    invalid-slots,
+    inherit-non-class,
+    inconsistent-mro,
+    duplicate-bases,
+    non-iterator-returned,
+    unexpected-special-method-signature,
+    invalid-length-returned,
+    relative-beyond-top-level,
+    used-before-assignment,
+    undefined-variable,
+    undefined-all-variable,
+    invalid-all-object,
+    no-name-in-module,
+    unpacking-non-sequence,
+    bad-except-order,
+    raising-bad-type,
+    bad-exception-context,
+    misplaced-bare-raise,
+    raising-non-exception,
+    notimplemented-raised,
+    catching-non-exception,
+    bad-super-call,
+    not-callable,
+    assignment-from-no-return,
+    no-value-for-parameter,
+    too-many-function-args,
+    unexpected-keyword-arg,
+    redundant-keyword-arg,
+    missing-kwoa,
+    invalid-sequence-index,
+    invalid-slice-index,
+    assignment-from-none,
+    not-context-manager,
+    invalid-unary-operand-type,
+    unsupported-binary-operation,
+    repeated-keyword,
+    not-an-iterable,
+    not-a-mapping,
+    unsupported-membership-test,
+    unsubscriptable-object,
+    unsupported-assignment-operation,
+    unsupported-delete-operation,
+    invalid-metaclass,
+    unhashable-dict-key,
+    logging-unsupported-format,
+    logging-format-truncated,
+    logging-too-many-args,
+    logging-too-few-args,
+    bad-format-character,
+    truncated-format-string,
+    mixed-format-string,
+    format-needs-mapping,
+    missing-format-string-key,
+    too-many-format-args,
+    too-few-format-args,
+    bad-string-format-type,
+    bad-str-strip-call,
+    invalid-envvar-value,
+    yield-inside-async-function,
+    not-async-context-manager,
+    useless-suppression,
+    deprecated-pragma,
+    use-symbolic-message-instead,
+    literal-comparison,
+    comparison-with-itself,
+    no-self-use,
+    no-classmethod-decorator,
+    no-staticmethod-decorator,
+    cyclic-import,
+    duplicate-code,
+    consider-merging-isinstance,
+    simplifiable-if-statement,
+    redefined-argument-from-local,
+    trailing-comma-tuple,
+    stop-iteration-return,
+    useless-return,
+    consider-swap-variables,
+    consider-using-join,
+    consider-using-in,
+    chained-comparison,
+    consider-using-dict-comprehension,
+    consider-using-set-comprehension,
+    simplifiable-if-expression,
+    unreachable,
+    pointless-statement,
+    pointless-string-statement,
+    expression-not-assigned,
+    unnecessary-pass,
+    unnecessary-lambda,
+    duplicate-key,
+    assign-to-new-keyword,
+    useless-else-on-loop,
+    confusing-with-statement,
+    using-constant-test,
+    comparison-with-callable,
+    lost-exception,
+    assert-on-tuple,
+    bad-staticmethod-argument,
+    super-init-not-called,
+    non-parent-init-called,
+    useless-super-delegation,
+    unnecessary-semicolon,
+    bad-indentation,
+    mixed-indentation,
+    deprecated-module,
+    reimported,
+    import-self,
+    misplaced-future,
+    global-variable-not-assigned,
+    unused-import,
+    unused-variable,
+    undefined-loop-variable,
+    unbalanced-tuple-unpacking,
+    possibly-unused-variable,
+    self-cls-assignment,
+    bare-except,
+    duplicate-except,
+    try-except-raise,
+    binary-op-exception,
+    raising-format-tuple,
+    wrong-exception-operation,
+    keyword-arg-before-vararg,
+    bad-format-string-key,
+    unused-format-string-key,
+    bad-format-string,
+    unused-format-string-argument,
+    format-combined-specification,
+    missing-format-attribute,
+    invalid-format-index,
+    anomalous-backslash-in-string,
+    anomalous-unicode-escape-in-string,
+    bad-open-mode,
+    redundant-unittest-assert,
+    deprecated-method,
+    bad-thread-instantiation,
+    shallow-copy-environ,
+    invalid-envvar-default,
+    deprecated-string-function,
+    deprecated-str-translate-call,
+    deprecated-itertools-function,
+    deprecated-types-field,


### PR DESCRIPTION
Run pylint on new/modified *.py files and fail if there are any
warnings.

Only enable a limited set of checks, focusing on logic issues and
relatively uncontroversial style stuff. We can tweak what checks are
enabled as we go.