### PR TITLE
scripts: Fix risky uses of non-raw regex strings in Python scripts

### DIFF
--- a/scripts/check_compliance.py
+++ b/scripts/check_compliance.py
@@ -430,7 +430,7 @@ class Codeowners(ComplianceTest):
         with open(codeowners, "r") as codeo:
             for line in codeo.readlines():
                 if not line.startswith("#") and line != "\n":
-                    match = re.match("([^\s]+)\s+(.*)", line)
+                    match = re.match(r"([^\s]+)\s+(.*)", line)
                     if match:
                         add_base = False
                         path = match.group(1)
@@ -633,14 +633,14 @@ class Identity(ComplianceTest):
             sha = ""
             parsed_addr = None
             for line in commit.split("\n"):
-                match = re.search("^commit\s([^\s]*)", line)
+                match = re.search(r"^commit\s([^\s]*)", line)
                 if match:
                     sha = match.group(1)
-                match = re.search("^Author:\s(.*)", line)
+                match = re.search(r"^Author:\s(.*)", line)
                 if match:
                     author = match.group(1)
                     parsed_addr = parseaddr(author)
-                match = re.search("signed-off-by:\s(.*)", line, re.IGNORECASE)
+                match = re.search(r"signed-off-by:\s(.*)", line, re.IGNORECASE)
                 if match:
                     signed.append(match.group(1))
 

--- a/scripts/gitlint/zephyr_commit_rules.py
+++ b/scripts/gitlint/zephyr_commit_rules.py
@@ -71,7 +71,7 @@ class SignedOffBy(CommitRule):
         flags |= re.IGNORECASE
         for line in commit.message.body:
             if line.lower().startswith("signed-off-by"):
-                if not re.search('(^)Signed-off-by: ([-\'\w.]+) ([-\'\w.]+) (.*)', line, flags=flags):
+                if not re.search(r"(^)Signed-off-by: ([-'\w.]+) ([-'\w.]+) (.*)", line, flags=flags):
                     return [RuleViolation(self.id, "Signed-off-by: must have a full name", line_nr=1)]
                 else:
                     return
@@ -111,7 +111,7 @@ class MaxLineLengthExceptions(LineRule):
 
     def validate(self, line, _commit):
         max_length = self.options['line-length'].value
-        urls = re.findall('http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+', line)
+        urls = re.findall(r'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+', line)
         if line.startswith('Signed-off-by'):
             return
 

--- a/scripts/merge_junit.py
+++ b/scripts/merge_junit.py
@@ -35,7 +35,7 @@ def merge_results(xml_files):
 
     for file_name in xml_files:
         tree = ET.parse(file_name)
-        test_suite = tree.findall('testsuite')[0];
+        test_suite = tree.findall('testsuite')[0]
         failures += int(test_suite.attrib['failures'])
         tests += int(test_suite.attrib['tests'])
         errors += int(test_suite.attrib['errors'])


### PR DESCRIPTION
Fixes pylint warnings like this one:

    scripts/check_compliance.py:326:0: W1401: Anomalous backslash in
    string: '\s'. String constant might be missing an r prefix.
    (anomalous-backslash-in-string)

The reason for this warning is that backslash escapes are interpreted in
non-raw (non-r-prefixed) strings. For example, '\a' and r'\a' are not
the same string (first one has a single ASCII bell character, second one
has two characters).

It just happens that there's no \s (or \\., or \\/) escape for example,
and '\s' turns into two characters (as needed for a regex). It's risky
to rely on stuff like that regexes though. Best to make them raw strings
unless they're super trivial.

Also note that '\s' and '\\\\s' turn into the same string.

Another tip: A literal ' can be put into a string with "blah'blah"
instead of 'blah\\'blah'.

Piggyback removal of a redundant semicolon.

zephyrproject-rtos/ci-tools#37 (just to link)