### PR TITLE
check_compliance: Use CMAKE_BINARY_DIR for Kconfig.modules

### DIFF
--- a/scripts/check_compliance.py
+++ b/scripts/check_compliance.py
@@ -259,7 +259,7 @@ class KconfigCheck(ComplianceTest):
         os.environ["ARCH_DIR"] = "arch/"
         os.environ["BOARD_DIR"] = "boards/*/*"
         os.environ["ARCH"] = "*"
-        os.environ["PROJECT_BINARY_DIR"] = tempfile.gettempdir()
+        os.environ["CMAKE_BINARY_DIR"] = tempfile.gettempdir()
         os.environ['GENERATED_DTS_BOARD_CONF'] = "dummy"
 
         # For multi repo support


### PR DESCRIPTION
Counterpart to Zephyr PR:
https://github.com/zephyrproject-rtos/zephyr/pull/14976

Part of the solution for:
https://github.com/zephyrproject-rtos/zephyr/issues/14974

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>