### PR TITLE
check_compliance.py: add comment explaining why Kconfig prints twice

### DIFF
--- a/scripts/check_compliance.py
+++ b/scripts/check_compliance.py
@@ -257,6 +257,10 @@ class KconfigCheck(ComplianceTest):
         os.environ["KCONFIG_WARN_UNDEF"] = "y"
 
         try:
+            # Note this will both print warnings to stderr _and_ return
+            # them: so some warnings might get printed
+            # twice. "warn_to_stderr=False" could unfortunately cause
+            # some (other) warnings to never be printed.
             return kconfiglib.Kconfig()
         except kconfiglib.KconfigError as e:
             self.add_failure(str(e))


### PR DESCRIPTION
Also explain why we can't just "warn_to_stderr=False" our way out of it.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>