### PR TITLE
check_compliance.py: fix broken exception handling in Kconfig

### DIFF
--- a/scripts/check_compliance.py
+++ b/scripts/check_compliance.py
@@ -213,13 +213,9 @@ class KconfigCheck(ComplianceTest):
         cmd = [sys.executable, zephyr_module_path,
                '--kconfig-out', modules_file]
         try:
-            p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                                 stderr=subprocess.PIPE)
-            p.communicate()
+            _ = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as ex:
-            self.skip("Command not found: " + str(e))
-        except sh.ErrorReturnCode as e:
-            self.skip(e)
+            self.error(ex.output)
 
     def parse_kconfig(self):
         """


### PR DESCRIPTION
PR #42 / Commit 4a2a1e17a488 "Use zephyr_module.py to generate
Kconfig.modules" totally failed to handle exceptions by trying to re-use
bits of existing code which was meant for something completely
different: - exception name mismatch ("ex" vs "e"); - irrelevant
sh.CommandNotFound exception left over; - use of the low-level
popen()/pcommunicate() which rarely ever raise exceptions; ...

To reproduce the issue, temporarily rename 'scripts/zephyr_module.py' to
something else and observe the Kconfig check silently passing despite
the lack of the main script and thanks to a /tmp/Kconfig.modules file
left behind by some previous run.

Clean-up the mess and simplify the code thanks to the higher-level and
recommended subprocess.run().

Maybe any /tmp/Kconfig.modules leftover should also be cleaned-up but
that's a different issue.

(This confirms the theory that error handling tends to have the worst
test coverage)

Signed-off-by: Marc Herbert <marc.herbert@intel.com>