### PR TITLE
check_compliance.py: UNDEF_KCONFIG_WHITELIST: add CONFIG_SHIFT

### DIFF
--- a/scripts/check_compliance.py
+++ b/scripts/check_compliance.py
@@ -401,6 +401,7 @@ UNDEF_KCONFIG_WHITELIST = {
     "CONFIG_REG1",
     "CONFIG_REG2",
     "CONFIG_SEL",
+    "CONFIG_SHIFT", #From STM32MP1 Cube (ext/hal/), file stm32mp1xx_ll_rcc.h
     "CONFIG_SOC_SERIES_",
     "CONFIG_SOC_WATCH",  # Issue 13749
     "CONFIG_SOME_BOOL",


### PR DESCRIPTION
Add CONFIG_SHIFT to Kconfig exclusion.
This definition is from LL from STM32MP1X Cube,
in ext/hal/st/stm32cube/stm32mp1xx/drivers/include/stm32mp1xx_ll_rcc.h.
This solve false positive in https://github.com/zephyrproject-rtos/zephyr/pull/15426

Signed-off-by: Yaël BOUTREUX <yael.boutreux@st.com>