### PR TITLE
requirements: require urllib3>=1.24.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@ python-dateutil==2.7.5
 requests==2.20.1
 sh==1.11
 six==1.11.0
-urllib3==1.24.1
+urllib3>=1.24.2
 wrapt==1.10.11
 colorama==0.4.1


### PR DESCRIPTION
CVE-2019-11324 More information

The urllib3 library before 1.24.2 for Python mishandles certain cases
where the desired set of CA certificates is different from the OS store
of CA certificates, which results in SSL connections succeeding in
situations where a verification failure is the correct outcome. This is
related to use of the ssl_context, ca_certs, or ca_certs_dir argument.