### PR TITLE
check_compliance.py: show which (sub)directory is being checked

### DIFF
--- a/scripts/check_compliance.py
+++ b/scripts/check_compliance.py
@@ -78,14 +78,14 @@ class ComplianceTest:
         self.commit_range = commit_range
         # get() defaults to None if not present
 
-    def prepare(self):
+    def prepare(self, where):
         """
         Prepare test case
         :return:
         """
         self.case = MyCase(self._name)
         self.case.classname = "Guidelines"
-        print("Running {} tests...".format(self._name))
+        print("Running {:16} tests in {} ...".format(self._name, where))
 
     def run(self):
         """
@@ -162,13 +162,14 @@ class CheckPatch(ComplianceTest):
     _doc = "https://docs.zephyrproject.org/latest/contribute/#coding-style"
 
     def run(self):
-        self.prepare()
+        self.prepare(GIT_TOP)
         # Default to Zephyr's checkpatch if ZEPHYR_BASE is set
         checkpatch = os.path.join(ZEPHYR_BASE or GIT_TOP, 'scripts',
                                   'checkpatch.pl')
         if not os.path.exists(checkpatch):
             self.skip(checkpatch + " not found")
 
+        # git diff's output doesn't depend on the current (sub)directory
         diff = subprocess.Popen(('git', 'diff', '%s' % (self.commit_range)),
                                 stdout=subprocess.PIPE)
         try:
@@ -192,7 +193,7 @@ class KconfigCheck(ComplianceTest):
     _doc = "https://docs.zephyrproject.org/latest/tools/kconfig/index.html"
 
     def run(self):
-        self.prepare()
+        self.prepare(ZEPHYR_BASE)
 
         kconf = self.parse_kconfig()
 
@@ -556,7 +557,7 @@ class Documentation(ComplianceTest):
     DOCS_WARNING_FILE = "doc.warnings"
 
     def run(self):
-        self.prepare()
+        self.prepare(os.getcwd())
 
         if os.path.exists(self.DOCS_WARNING_FILE) and os.path.getsize(self.DOCS_WARNING_FILE) > 0:
             with open(self.DOCS_WARNING_FILE, "rb") as docs_warning:
@@ -572,7 +573,7 @@ class GitLint(ComplianceTest):
     _doc = "https://docs.zephyrproject.org/latest/contribute/#commit-guidelines"
 
     def run(self):
-        self.prepare()
+        self.prepare(os.path.join(os.getcwd(), '[.gitlint]'))
 
         proc = subprocess.Popen('gitlint --commits %s' % (self.commit_range),
                                 shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
@@ -594,13 +595,15 @@ class License(ComplianceTest):
     _doc = "https://docs.zephyrproject.org/latest/contribute/#licensing"
 
     def run(self):
-        self.prepare()
+        # copyfile() below likely requires that getcwd()==GIT_TOP
+        self.prepare(os.getcwd())
 
         scancode = "/opt/scancode-toolkit/scancode"
         if not os.path.exists(scancode):
             self.skip("scancode-toolkit not installed")
 
         os.makedirs("scancode-files", exist_ok=True)
+        # git diff's output doesn't depend on the current (sub)directory
         new_files = sh.git("diff", "--name-only", "--diff-filter=A",
                            self.commit_range, **sh_special_args)
 
@@ -693,11 +696,13 @@ class Identity(ComplianceTest):
     _doc = "https://docs.zephyrproject.org/latest/contribute/#commit-guidelines"
 
     def run(self):
-        self.prepare()
+        # git rev-list and git log don't depend on the current
+        # (sub)directory unless explicited.
+        self.prepare(GIT_TOP)
 
-        for file in get_shas(self.commit_range):
+        for shaidx in get_shas(self.commit_range):
             commit = sh.git("log", "--decorate=short",
-                            "-n 1", file, **sh_special_args)
+                            "-n 1", shaidx, **sh_special_args)
             signed = []
             author = ""
             sha = ""

--- a/scripts/check_compliance.py
+++ b/scripts/check_compliance.py
@@ -35,8 +35,10 @@ sh_special_args = {
     '_cwd': os.getcwd()
 }
 
+ZEPHYR_BASE = os.environ.get('ZEPHYR_BASE')
 # The absolute path of the top-level git directory
-git_top = sh.git("rev-parse", "--show-toplevel").strip()
+GIT_TOP = sh.git("rev-parse", "--show-toplevel").strip()
+
 
 def get_shas(refspec):
     """
@@ -75,7 +77,6 @@ class ComplianceTest:
         self.suite = suite
         self.commit_range = commit_range
         # get() defaults to None if not present
-        self.zephyr_base = os.environ.get('ZEPHYR_BASE')
 
     def prepare(self):
         """
@@ -163,7 +164,7 @@ class CheckPatch(ComplianceTest):
     def run(self):
         self.prepare()
         # Default to Zephyr's checkpatch if ZEPHYR_BASE is set
-        checkpatch = os.path.join(self.zephyr_base or git_top, 'scripts',
+        checkpatch = os.path.join(ZEPHYR_BASE or GIT_TOP, 'scripts',
                                   'checkpatch.pl')
         if not os.path.exists(checkpatch):
             self.skip(checkpatch + " not found")
@@ -174,7 +175,7 @@ class CheckPatch(ComplianceTest):
             subprocess.check_output((checkpatch, '--mailback', '--no-tree', '-'),
                                     stdin=diff.stdout,
                                     stderr=subprocess.STDOUT,
-                                    shell=True, cwd=git_top)
+                                    shell=True, cwd=GIT_TOP)
 
         except subprocess.CalledProcessError as ex:
             output = ex.output.decode("utf-8")
@@ -209,7 +210,7 @@ class KconfigCheck(ComplianceTest):
         """
         # Invoke the script directly using the Python executable since this is
         # not a module nor a pip-installed Python utility
-        zephyr_module_path = os.path.join(self.zephyr_base, "scripts",
+        zephyr_module_path = os.path.join(ZEPHYR_BASE, "scripts",
                                           "zephyr_module.py")
         cmd = [sys.executable, zephyr_module_path,
                '--kconfig-out', modules_file]
@@ -223,12 +224,12 @@ class KconfigCheck(ComplianceTest):
         Returns a kconfiglib.Kconfig object for the Kconfig files. We reuse
         this object for all tests to avoid having to reparse for each test.
         """
-        if not self.zephyr_base:
+        if not ZEPHYR_BASE:
             self.skip("Not a Zephyr tree (ZEPHYR_BASE unset)")
 
         # Put the Kconfiglib path first to make sure no local Kconfiglib version is
         # used
-        kconfig_path = os.path.join(self.zephyr_base, "scripts", "kconfig")
+        kconfig_path = os.path.join(ZEPHYR_BASE, "scripts", "kconfig")
         if not os.path.exists(kconfig_path):
             self.error(kconfig_path + " not found")
 
@@ -236,7 +237,7 @@ class KconfigCheck(ComplianceTest):
         import kconfiglib
 
         # Look up Kconfig files relative to ZEPHYR_BASE
-        os.environ["srctree"] = self.zephyr_base
+        os.environ["srctree"] = ZEPHYR_BASE
 
         # Parse the entire Kconfig tree, to make sure we see all symbols
         os.environ["SOC_DIR"] = "soc/"
@@ -321,7 +322,7 @@ entries, then bump the 'max_top_items' variable in {}.
         grep_process = subprocess.Popen(grep_cmd.split(),
                                         stdout=subprocess.PIPE,
                                         stderr=subprocess.PIPE,
-                                        cwd=self.zephyr_base)
+                                        cwd=ZEPHYR_BASE)
 
         grep_stdout, grep_stderr = grep_process.communicate()
         # Fail if there's anything on stderr too, so that it doesn't get missed
@@ -446,7 +447,7 @@ class Codeowners(ComplianceTest):
         # files :-(
 
         pattern2files = collections.OrderedDict()
-        top_path = Path(git_top)
+        top_path = Path(GIT_TOP)
 
         with open(codeowners, "r") as codeo:
             for lineno, line in enumerate(codeo, start=1):
@@ -488,18 +489,18 @@ class Codeowners(ComplianceTest):
 
         if git_pattern.endswith("/"):
             ret = ret + "**/*"
-        elif os.path.isdir(os.path.join(git_top, ret)):
+        elif os.path.isdir(os.path.join(GIT_TOP, ret)):
             self.add_failure("Expected '/' after directory '{}' "
                              "in CODEOWNERS".format(ret))
 
         return ret
 
     def run(self):
-        self.prepare()
+        self.prepare(GIT_TOP)
         # TODO: testing an old self.commit range that doesn't end
         # with HEAD is most likely a mistake. Should warn, see
         # https://github.com/zephyrproject-rtos/ci-tools/pull/24
-        codeowners = os.path.join(git_top, "CODEOWNERS")
+        codeowners = os.path.join(GIT_TOP, "CODEOWNERS")
         if not os.path.exists(codeowners):
             self.skip("CODEOWNERS not available in this repo")
 


### PR DESCRIPTION
When run outside ZEPHYR_BASE, the tests in check_compliance.py behave in
various ways: some check the current repo while others stick to
ZEPHYR_BASE. Some run in a subdirectory while others stick to GIT_TOP,
Some don't mind being run from a subdirectory while others fail.

Some of these inconsistencies make sense while others are limitations
that should probably be fixed. However the first step is awareness and
clarifying mysteries so this commit purely prints which (sub)directory
is being checked for every test while making absolutely zero functional
change.

Sample output:
```
cd zephyr-ci-tools/scripts/

Running checkpatch       in /home/joe/zephyr-ci-tools ...
Running Kconfig          in /home/joe/zephyr ...
Running Codeowners       in /home/joe/zephyr-ci-tools ...
Running Documentation    in /home/joe/zephyr-ci-tools/scripts ...
Running Gitlint          in /home/joe/zephyr-ci-tools/scripts/[.gitlint]..
Running License          in /home/joe/zephyr-ci-tools/scripts ...
Running Identity/Emails  in /home/joe/zephyr-ci-tools ...
```
get ZEPHYR_BASE env only once, not ~ 15 times

Also rename git_top constant to GIT_TOP because pylint says so.