### PR TITLE
scripts: Fix broken module docstrings and bad indentation

### DIFF
--- a/scripts/check_compliance.py
+++ b/scripts/check_compliance.py
@@ -350,7 +350,7 @@ entries, then bump the 'max_top_items' variable in {}.
             if sym_name[7:] not in defined_syms and \
                sym_name not in UNDEF_KCONFIG_WHITELIST:
 
-               undef_to_locs[sym_name].append("{}:{}".format(path, lineno))
+                undef_to_locs[sym_name].append("{}:{}".format(path, lineno))
 
         if not undef_to_locs:
             return

--- a/scripts/gitlint/zephyr_commit_rules.py
+++ b/scripts/gitlint/zephyr_commit_rules.py
@@ -3,10 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from gitlint.rules import CommitRule, RuleViolation, CommitMessageTitle, LineRule, CommitMessageBody
-from gitlint.options import IntOption, StrOption
-import re
-
 """
 The classes below are examples of user-defined CommitRules. Commit rules are gitlint rules that
 act on the entire commit at once. Once the rules are discovered, gitlint will automatically take care of applying them
@@ -19,6 +15,11 @@ that should only be done once per gitlint run.
 While every LineRule can be implemented as a CommitRule, it's usually easier and more concise to go with a LineRule if
 that fits your needs.
 """
+
+from gitlint.rules import CommitRule, RuleViolation, CommitMessageTitle, LineRule, CommitMessageBody
+from gitlint.options import IntOption, StrOption
+import re
+
 
 class BodyMinLineCount(CommitRule):
     # A rule MUST have a human friendly name

--- a/scripts/merge_junit.py
+++ b/scripts/merge_junit.py
@@ -3,16 +3,15 @@
 #  Corey Goldberg, Dec 2012
 #
 
-import os
-import sys
-import xml.etree.ElementTree as ET
-
-
 """Merge multiple JUnit XML files into a single results file.
 Output dumps to sdtdout.
 example usage:
     $ python merge_junit_results.py results1.xml results2.xml > results.xml
 """
+
+import os
+import sys
+import xml.etree.ElementTree as ET
 
 
 def main():


### PR DESCRIPTION
The docstring needs to come first in the file. Fixes these pylint
warnings:

```
scripts/gitlint/zephyr_commit_rules.py:21:-1: W0105: String statement has no effect (pointless-string-statement)

scripts/merge_junit.py:15:-1: W0105: String statement has no effect (pointless-string-statement)
```

Also fix a misindented line that got flagged.