### PR TITLE
check_compliance.py: run gitlint in GIT_TOP

### DIFF
--- a/scripts/check_compliance.py
+++ b/scripts/check_compliance.py
@@ -575,10 +575,13 @@ class GitLint(ComplianceTest):
     _doc = "https://docs.zephyrproject.org/latest/contribute/#commit-guidelines"
 
     def run(self):
-        self.prepare(os.path.join(os.getcwd(), '[.gitlint]'))
+        self.prepare(GIT_TOP)
 
+        # By default gitlint looks for .gitlint configuration only in
+        # the current directory
         proc = subprocess.Popen('gitlint --commits %s' % (self.commit_range),
-                                shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                                stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                                shell=True, cwd=GIT_TOP)
 
         msg = ""
         if proc.wait() != 0:


### PR DESCRIPTION
gitlint is very "flexible" - and confusing: it can run from any
sub-directory but looks for .gitlint configuration only in the current
directory. For instance running:

  check_compliance.py -c 4fc250489d~..

... in this repo reports a slightly different set of issues depending on
what the current sub-directory is.

Zephyr is not interested in per-directory rules right now; always run
gitlint in GIT_TOP where the single .gitlint is.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>