### PR TITLE
codeowners: add missing checks on renames and deletions

### DIFF
--- a/scripts/check_compliance.py
+++ b/scripts/check_compliance.py
@@ -534,23 +534,30 @@ class Codeowners(ComplianceTest):
         if not os.path.exists(codeowners):
             self.skip("CODEOWNERS not available in this repo")
 
-        commit = git("diff", "--name-only", "--diff-filter=A",
-                     self.commit_range)
-        new_files = commit.splitlines()
-        logging.debug("New files %s", new_files)
+        name_changes = git("diff", "--name-only", "--diff-filter=ARCD",
+                            self.commit_range)
 
-        if not new_files:
-            # TODO: parse CODEOWNERS to report errors in it *without*
-            # scanning the tree to keep this case very fast.
+        if not name_changes:
+            # TODO: 1. decouple basic and cheap CODEOWNERS syntax
+            # validation from the expensive ls_owned_files() scanning of
+            # the entire tree. 2. run the former always.
             return
+
+        logging.info("If this takes too long then cleanup and try again")
+        patrn2files = self.ls_owned_files(codeowners)
+
+        # The way git finds Renames and Copies is not "exact science",
+        # however if one is missed then it will always be reported as an
+        # Addition instead.
+        new_names = git("diff", "--name-only", "--diff-filter=ARC",
+                     self.commit_range)
+        new_files = new_names.splitlines()
+        logging.debug("New files %s", new_files)
 
         # Convert to pathlib.Path string representation (e.g.,
         # backslashes 'dir1\dir2\' on Windows) to be consistent
         # with self.ls_owned_files()
         new_files = [str(Path(f)) for f in new_files]
-
-        logging.info("If this takes too long then cleanup and try again")
-        patrn2files = self.ls_owned_files(codeowners)
 
         new_not_owned = []
         for newf in new_files:

--- a/scripts/check_compliance.py
+++ b/scripts/check_compliance.py
@@ -537,7 +537,10 @@ class Codeowners(ComplianceTest):
         name_changes = git("diff", "--name-only", "--diff-filter=ARCD",
                             self.commit_range)
 
-        if not name_changes:
+        owners_changes = git("diff", "--name-only", self.commit_range,
+                             "--", codeowners)
+
+        if not name_changes and not owners_changes:
             # TODO: 1. decouple basic and cheap CODEOWNERS syntax
             # validation from the expensive ls_owned_files() scanning of
             # the entire tree. 2. run the former always.


### PR DESCRIPTION
This fixes two issues:

- An overly agressive optimization that returned before checking the
  CODEOWNERS files on renames and deletions. This could leave stale
  entries in CODEOWNERS which are noticed (much) later by the next
  commit adding new files. See example in PR [#17075](https://github.com/zephyrproject-rtos/zephyr/pull/17075) paying the price for
  PR [#17054](https://github.com/zephyrproject-rtos/zephyr/pull/17054) and others. This is fixed by moving the recursive scan earlier and
  making the optimization less agressive.

- A simpler, one-missing-character bug that failed to include moved
  files in the set of new files. Since CODEOWNERS is path-based they
  must be treated as such.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>