### PR TITLE
what_changed: Add entry for Bluetooth Mesh

### DIFF
--- a/scripts/what_changed.py
+++ b/scripts/what_changed.py
@@ -244,6 +244,13 @@ def main():
                 "labels": ["area: Bluetooth"]
                 },
             {
+                "area": "Bluetooth Mesh",
+                "regex" : ["^subsys/bluetooth/mesh"],
+                "counter": 0,
+                "labels": ["area: Bluetooth Mesh"]
+                },
+ 
+            {
                 "area": "API",
                 "regex" : ["^include/"],
                 "counter": 0,


### PR DESCRIPTION
Add a new entry for the newly created Bluetooth Mesh label.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>