### PR TITLE
Suppress/fix pylint warnings

### DIFF
--- a/scripts/check_compliance.py
+++ b/scripts/check_compliance.py
@@ -41,6 +41,10 @@ def git(*args):
     # Hack: Setting _cwd to the working dir seems pointless as of writing (it
     # should be the default), but keep it around in case it's working around
     # some issue
+
+    # pylint doesn't like how the sh library works.
+    #
+    # pylint: disable=unexpected-keyword-arg
     return sh.git(*args, _tty_out=False, _cwd=os.getcwd())
 
 
@@ -102,7 +106,6 @@ class ComplianceTest:
         Run testcase
         :return:
         """
-        pass
 
     def error(self, msg):
         """


### PR DESCRIPTION
pylint doesn't like how the sh library works.

Fixes these warnings:

     scripts/check_compliance.py:44:11: E1123: Unexpected keyword argument
     '_tty_out' in function call (unexpected-keyword-arg)

     scripts/check_compliance.py:44:11: E1123: Unexpected keyword argument
     '_cwd' in function call (unexpected-keyword-arg)

     scripts/check_compliance.py:105:8: W0107: Unnecessary pass statement
     (unnecessary-pass)