### PR TITLE
check_compliance.py: Add dummy DTS_POST_CPP env var

### DIFF
--- a/scripts/check_compliance.py
+++ b/scripts/check_compliance.py
@@ -260,6 +260,7 @@ class KconfigCheck(ComplianceTest):
         os.environ["ARCH"] = "*"
         os.environ["CMAKE_BINARY_DIR"] = tempfile.gettempdir()
         os.environ['GENERATED_DTS_BOARD_CONF'] = "dummy"
+        os.environ['DTS_POST_CPP'] = 'dummy'
 
         # For multi repo support
         self.get_modules(os.path.join(tempfile.gettempdir(), "Kconfig.modules"))


### PR DESCRIPTION
The kconfig test needs a dummy setting so in-flight changes to
kconfigfunctions.py will pass tests.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>