### PR TITLE
check_compliance.py/what_changed.py: Remove 'sh' library dependency and fix pylint warnings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ PyJWT==1.7.1
 python-dateutil==2.7.5
 python-magic==0.4.15
 requests==2.20.1
-sh==1.11
 six==1.11.0
 urllib3>=1.24.2
 wrapt==1.10.11

--- a/scripts/what_changed.py
+++ b/scripts/what_changed.py
@@ -6,9 +6,7 @@
 
 # A script to set labels on pull-rquests based on files being changed
 
-import sys
 import re, os
-from email.utils import parseaddr
 import sh
 import argparse
 from github import Github
@@ -46,21 +44,12 @@ def parse_args():
     return parser.parse_args()
 
 def main():
-    boards = set()
-
     args = parse_args()
     if not args.commits:
         exit(1)
 
     commit = git("diff","--name-only", args.commits)
     files = commit.split("\n")
-
-    docs = 0
-    images = 0
-    kernel = 0
-    code = 0
-    net = 0
-    bt = 0
 
     matches = [
             {
@@ -249,7 +238,6 @@ def main():
                 "counter": 0,
                 "labels": ["area: Bluetooth Mesh"]
                 },
- 
             {
                 "area": "API",
                 "regex" : ["^include/"],
@@ -282,7 +270,7 @@ def main():
                 },
             {
                 "area": "Documentation",
-                "regex" : ["^doc/", "\.rst$", "\.txt$"],
+                "regex" : ["^doc/", r"\.rst$", r"\.txt$"],
                 "counter": 0,
                 "labels": ["area: Documentation"]
                 },
@@ -330,8 +318,6 @@ def main():
         exit(0)
 
     if args.pull_request and args.repo:
-        username = os.environ.get('GH_USERNAME', 'zephyrbot')
-
         github_token = os.environ['GH_TOKEN']
         github_conn = Github(github_token)
 


### PR DESCRIPTION
Two fixes, which together get rid of all warnings for `what_changed.py` and get rid of the `sh` library.

Getting rid of the `sh` library was prompted by fixing the warnings, but it seems to have other nice side effects too, like Windows compatibility (for the Git part at least).

```
what_changed.py: Remove unused variables and imports

Fixes pylint warnings and makes the script easier to read.

Also fix two regex-related warnings:

    what_changed.py:273:0: W1401: Anomalous backslash in string: '\.'.
    String constant might be missing an r prefix.
    (anomalous-backslash-in-string)

There's still two warnings related to the 'sh' library. Those will be
fixed separately by removing it.
```

```
check_compliance.py/what_changed.py: Remove 'sh' library dependency

Having this third-party library just for the git() helper is a bit
overkill. Use the plain subprocess module instead.

Also improve error reporting, e.g. to show the command when things fail.
In check_compliance.py, the sys.exit()s will generate SystemExit
exceptions that trickle through to the top-level and get reported to
GitHub.
```