### PR TITLE
check_compliance.py: pylint: Detect Python files not ending in .py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ kconfiglib==10.30.0
 PyGithub==1.43.3
 PyJWT==1.7.1
 python-dateutil==2.7.5
+python-magic==0.4.15
 requests==2.20.1
 sh==1.11
 six==1.11.0


### PR DESCRIPTION
Use the python-magic library to detect added/changed Python files even
if they don't end in .py. This will detect e.g.
scripts/footprint/size_report in the Zephyr repo.

scripts/sanitycheck is currently being overhauled, so skip it manually
for now. It will be checked later.