### PR TITLE
check_compliance.py: Fix Licence and Codeowners checks

### DIFF
--- a/scripts/check_compliance.py
+++ b/scripts/check_compliance.py
@@ -613,9 +613,8 @@ class Codeowners(ComplianceTest):
         # The way git finds Renames and Copies is not "exact science",
         # however if one is missed then it will always be reported as an
         # Addition instead.
-        new_names = git("diff", "--name-only", "--diff-filter=ARC",
-                     self.commit_range)
-        new_files = new_names.splitlines()
+        new_files = git("diff", "--name-only", "--diff-filter=ARC",
+                        self.commit_range).splitlines()
         logging.debug("New files %s", new_files)
 
         # Convert to pathlib.Path string representation (e.g.,
@@ -767,7 +766,7 @@ class License(ComplianceTest):
         os.makedirs("scancode-files", exist_ok=True)
         # git diff's output doesn't depend on the current (sub)directory
         new_files = git("diff", "--name-only", "--diff-filter=A",
-                        self.commit_range)
+                        self.commit_range).splitlines()
 
         if not new_files:
             return


### PR DESCRIPTION
The 'sh' library seems to have some magic for iterating over lines,
which the License check relied on (maybe accidentally). The check broke
when the 'sh' library was removed in commit 3f6c5f9
("check_compliance.py/what_changed.py: Remove 'sh' library dependency
and fix pylint warnings"):

    Traceback (most recent call last):
      File ".../check_compliance.py", line 1210, in main
        n_fails = _main(args)
      File ".../check_compliance.py", line 1156, in _main
        test.run()
      File ".../check_compliance.py", line 780, in run
        copyfile(file, copy)
      File ".../shutil.py", line 114, in copyfile
        with open(src, 'rb') as fsrc:
    FileNotFoundError: [Errno 2] No such file or directory: 'b'

(The 'b' there is the first character of a filename.)

Fix it by running .splitlines() on the reusult of git().

Make a similar change to the Codeowners check, which looks like it might
have the same issue.