### PR TITLE
check_compliance.py: Always show warnings from checkpatch.pl

### DIFF
--- a/scripts/check_compliance.py
+++ b/scripts/check_compliance.py
@@ -222,6 +222,9 @@ class CheckPatch(ComplianceTest):
             output = ex.output.decode("utf-8")
             if re.search("[1-9][0-9]* errors,", output):
                 self.add_failure(output)
+            else:
+                # No errors found, but warnings. Show them.
+                self.add_info(output)
 
 
 class KconfigCheck(ComplianceTest):


### PR DESCRIPTION
First commit adds support for informational messages from tests. Second commit uses it to report warnings from the `CheckPatch` test, even when there are no errors that would fail the test.

```
check_compliance.py: Add support for informational messages

Add a new ComplianceTest.add_info() function for showing informational
messages in tests without failing the test. Informational messages are
always shown on GitHub, regardless of whether the test succeeds or not.

CI runs check_compliance.py several times and keeps track of test
results by saving them to JUnit XML files that later get loaded, which
complicates things. To preserve informational messages, save them in a
new 'info_msg' attribute on <testcase> (added via the custom MyCase
class).

Piggyback removal of a declared-but-unused (never set) 'doc' attribute
on <testcase>, and some minor EDIT_TIP cleanup (add it in
github_comment(), since it should always appear).
```

```
check_compliance.py: Always show warnings from checkpatch.pl

Always show the output from checkpatch.pl on GitHub, even if there are
no errors. This way, warnings will always be seen.

checkpatch.pl produces no output if there are neither warnings nor
errors (because of --mailback), so this won't cause GitHub spam.

Fixes: #63
```