### PR TITLE
python: add cbor 1.0.0 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 arrow==0.10.0
 certifi==2018.11.29
+cbor==1.0.0
 chardet==3.0.4
 click==6.6
 Deprecated==1.2.4


### PR DESCRIPTION
This commit adds `cbor==1.0.0` to the `requirements.txt` file. This
is required for TF-M tests to pass in CI with Zephyr RTOS for
https://github.com/zephyrproject-rtos/zephyr/pull/19985

Signed-off-by: Kevin Townsend <kevin.townsend@linaro.org>