### PR TITLE
zephyr_commit_rules.py: Fix pylint warning re. 'len(urls) > 0'

### DIFF
--- a/scripts/gitlint/zephyr_commit_rules.py
+++ b/scripts/gitlint/zephyr_commit_rules.py
@@ -116,7 +116,7 @@ class MaxLineLengthExceptions(LineRule):
         if line.startswith('Signed-off-by'):
             return
 
-        if len(urls) > 0:
+        if urls:
             return
 
         if len(line) > max_length:


### PR DESCRIPTION
'if len(urls) > 0:' can be simplified to 'if urls:'. Fixes this
pylint warning:

    ************* Module zephyr_commit_rules
    scripts/ci/gitlint/zephyr_commit_rules.py:119:11: C1801: Do not use
    `len(SEQUENCE)` to determine if a sequence is empty
    (len-as-condition)