### PR TITLE
check_compliance.py: Make license check informational

### DIFF
--- a/scripts/check_compliance.py
+++ b/scripts/check_compliance.py
@@ -868,12 +868,15 @@ class License(ComplianceTest):
                         report += ("* {} missing copyright.\n".format(orig_path))
 
         if report != "":
-            self.add_failure("""
-In most cases you do not need to do anything here, especially if the files
-reported below are going into ext/ and if license was approved for inclusion
-into ext/ already. Fix any missing license/copyright issues. The license
-exception if a JFYI for the maintainers and can be overriden when merging the
-pull request.\n\n""" + report)
+            self.add_info("""
+This is just an FYI for maintainers. In most cases you do not need to do
+anything here, especially if the files reported below are going into ext/ and
+the license was approved for inclusion into ext/ already. Fix any missing
+license/copyright issues.
+
+A compact format is encouraged, to avoid too much boilerplate in files.
+
+""" + report)
 
 
 class Identity(ComplianceTest):


### PR DESCRIPTION
Since this check is often a manual-inspection type thing, turn it into
an informational message instead of a failure. That might avoid people
needlessly changing stuff just to please the check and get a green
checkmark, or people holding off on their review because they think
there's problems with the code.

Also encourage a compact style in the message.