### PR TITLE
Revert "check_compliance.py: Make license check informational"

### DIFF
--- a/scripts/check_compliance.py
+++ b/scripts/check_compliance.py
@@ -876,15 +876,12 @@ class License(ComplianceTest):
                         report += ("* {} missing copyright.\n".format(orig_path))
 
         if report != "":
-            self.add_info("""
-This is just an FYI for maintainers. In most cases you do not need to do
-anything here, especially if the files reported below are going into ext/ and
-the license was approved for inclusion into ext/ already. Fix any missing
-license/copyright issues.
-
-A compact format is encouraged, to avoid too much boilerplate in files.
-
-""" + report)
+            self.add_failure("""
+In most cases you do not need to do anything here, especially if the files
+reported below are going into ext/ and if license was approved for inclusion
+into ext/ already. Fix any missing license/copyright issues. The license
+exception if a JFYI for the maintainers and can be overriden when merging the
+pull request.\n\n""" + report)
 
 
 class Identity(ComplianceTest):


### PR DESCRIPTION
This reverts commit 747795b933555036af09ed7de7e76900aaec7b3b.

We want the license check to error out.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>