### PR TITLE
check_compliance.py: Add STACK_SIZE to Kconfig symbol whitelist

### DIFF
--- a/scripts/check_compliance.py
+++ b/scripts/check_compliance.py
@@ -486,6 +486,7 @@ UNDEF_KCONFIG_WHITELIST = {
     "SOME_INT",
     "SOME_OTHER_BOOL",
     "SOME_STRING",
+    "STACK_SIZE",  # Used as an example in the Kconfig docs
     "STD_CPP",  # Referenced in CMake comment
     "TEST1",
     "TYPE_BOOLEAN",


### PR DESCRIPTION
Needed for https://github.com/zephyrproject-rtos/zephyr/pull/20722.

Signed-off-by: Ulf Magnusson <Ulf.Magnusson@nordicsemi.no>