### PR TITLE
check_compliance.py: s/GENERATED_DTS_BOARD_CONF/DEVICETREE_CONF/

### DIFF
--- a/scripts/check_compliance.py
+++ b/scripts/check_compliance.py
@@ -283,7 +283,7 @@ class KconfigCheck(ComplianceTest):
         os.environ["BOARD_DIR"] = "boards/*/*"
         os.environ["ARCH"] = "*"
         os.environ["CMAKE_BINARY_DIR"] = tempfile.gettempdir()
-        os.environ['GENERATED_DTS_BOARD_CONF'] = "dummy"
+        os.environ['DEVICETREE_CONF'] = "dummy"
         os.environ['DTS_POST_CPP'] = 'dummy'
 
         # For multi repo support


### PR DESCRIPTION
Needed for https://github.com/zephyrproject-rtos/zephyr/pull/20757.