### PR TITLE
check_compliance.py: Fix running Kconfig/pylint checks outside top dir

### DIFF
--- a/scripts/check_compliance.py
+++ b/scripts/check_compliance.py
@@ -432,7 +432,7 @@ def get_defined_syms(kconf):
 
     # Grep samples/ and tests/ for symbol definitions
     grep_stdout = git("grep", "-I", "-h", "--extended-regexp", regex, "--",
-                      ":samples", ":tests")
+                      ":samples", ":tests", cwd=ZEPHYR_BASE)
 
     # Start with the symbols from the main Kconfig tree in 'res'
     res = set(sym.name for sym in kconf.unique_defined_syms)
@@ -802,7 +802,8 @@ class PyLint(ComplianceTest):
 
     def run(self):
         # Path to pylint configuration file
-        pylintrc = os.path.join(os.path.dirname(__file__), "pylintrc")
+        pylintrc = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                "pylintrc"))
 
         # List of files added/modified by the commit(s).
         files = git(


### PR DESCRIPTION
The PyLint and KconfigCheck tests are broken when not run from the
top-level repository directory. Fix it by making the path to pylintrc
absolute and explicitly running the 'git grep' for Kconfig definitions
in samples/ and tests/ from the top-level Zephyr directory.

The root cause was a mismatch between paths and process working
directories.