### PR TITLE
requirements.txt: Do not install (an old version of) Kconfiglib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ future==0.17.1
 gitlint==0.10.0
 idna==2.7
 junitparser==1.2.2
-kconfiglib==10.30.0
 PyGithub==1.43.3
 PyJWT==1.7.1
 python-dateutil==2.7.5


### PR DESCRIPTION
The KconfigCheck test in check_compliance.py uses
scripts/kconfig/kconfiglib.py from Zephyr, and nothing else needs
Kconfiglib to be installed from PyPI either.

Installing the old 10.30.0 version of Kconfiglib makes pylint generate a
warning-turned-error for genrest.py, because it uses a the
suppress_traceback parameter to `Kconfig.__init__()`, which was added
later.