### PR TITLE
check_compliance.py: Don't error out for internal test(e)dtlib errors

### DIFF
--- a/scripts/check_compliance.py
+++ b/scripts/check_compliance.py
@@ -532,6 +532,9 @@ class DeviceTreeCheck(ComplianceTest):
             # which raises SystemExit. Let any errors in the test scripts
             # themselves trickle through and turn into an internal CI error.
             self.add_failure(str(e))
+        except Exception as e:
+            # Report other exceptions as an internal test failure
+            self.error(str(e))
         finally:
             # Restore working directory
             os.chdir(old_dir)


### PR DESCRIPTION
Instead of catching DeviceTreeCheck exceptions from test(e)dtlib.py all
the way up in main(), catch them in the DeviceTreeCheck test itself, and
report them with ComplianceTest.error().

That way, other tests (e.g. pylint) can still run and report to GitHub
when there are internal errors in test(e)dtlib.py.

Motivated by https://github.com/zephyrproject-rtos/zephyr/pull/22255.