### PR TITLE
python: add imgtool 1.6.0 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ Deprecated==1.2.4
 future==0.17.1
 gitlint==0.10.0
 idna==2.7
+imgtool==1.6.0
 junitparser==1.2.2
 PyGithub==1.43.3
 PyJWT==1.7.1


### PR DESCRIPTION
This commit adds `imgtool==1.6.0` to the `requirements.txt`
file. This is needed for TF-M integration samples to build
in CI with Zephyr RTOS with the latest TF-M:
zephyrproject-rtos/trusted-firmware-m#15.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>